### PR TITLE
Added status tot error span

### DIFF
--- a/pkg/otelinji/otelinji.go
+++ b/pkg/otelinji/otelinji.go
@@ -1,6 +1,7 @@
 package otelinji
 
 import (
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -11,6 +12,7 @@ func EndSpanWithErr(
 	options ...trace.SpanEndOption,
 ) {
 	if err != nil {
+		span.SetStatus(codes.Error, "error")
 		span.RecordError(err)
 	}
 


### PR DESCRIPTION
Docs recommend to set status too: https://opentelemetry.io/docs/instrumentation/go/manual/#record-errors

not dumping `err.Error()` since as I understand error is already passed in `RecordError`, besides if `Error()` message is too long it may fail (I don't know what is largest SetStatus supports), so safer just to same something short.

<img width="1374" alt="image" src="https://user-images.githubusercontent.com/2933061/200114499-bbb9456f-54dd-4e54-9823-4da5124af4e8.png">
