### PR TITLE
ci: release with built-in token, PAT only for brew tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    permissions:
+      # Required to create the GitHub release with the built-in token.
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -23,7 +26,11 @@ jobs:
           version: '~> v2'
           args: release --clean
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+          # Built-in token: enough for creating the release in this repo.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # PAT with write access to hedhyw/homebrew-main: only needed for
+          # pushing the Homebrew formula to the tap repository.
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.GH_PAT }}
 
   docker:
     runs-on: ubuntu-latest
@@ -33,7 +40,7 @@ jobs:
 
       - name: Set output
         id: vars
-        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+        run: echo "tag=${GITHUB_REF#refs/*/}" >> "$GITHUB_OUTPUT"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,5 @@
+version: 2
+
 builds:
   - binary: otelinji
     main: ./cmd/otelinji
@@ -28,7 +30,8 @@ archives:
       - LICENSE
     format_overrides:
       - goos: windows
-        format: zip
+        formats:
+          - zip
 
 release:
   draft: true
@@ -58,6 +61,9 @@ brews:
     repository:
       owner: hedhyw
       name: homebrew-main
+      # Cross-repo push requires a PAT; the built-in GITHUB_TOKEN cannot
+      # write to other repositories.
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     test: system "#{bin}/otelinji", "-help"
     install: |-
       bin.install "otelinji"


### PR DESCRIPTION
Fixes release failure (v1.1.0 died with `401 Bad credentials` — stale `GH_PAT`):

- GitHub release now uses the built-in `GITHUB_TOKEN` — no PAT needed
- `GH_PAT` only used for the homebrew-main formula push
- Also: `::set-output` deprecation fixed, goreleaser config updated to v2 schema

After merge: regenerate `GH_PAT` (write access to homebrew-main), then re-run the release — delete and repush the tag if the rerun still uses the old workflow.

Same fix applies to gherkingen.