### PR TITLE
fix: release pipeline token and docker build

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,15 @@ updates:
     pull-request-branch-name:
       separator: "/"
 
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    commit-message:
+      prefix: "chore(docker)"
+    pull-request-branch-name:
+      separator: "/"
+
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    permissions:
+      # Required to create the GitHub release with the built-in token.
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -23,7 +26,11 @@ jobs:
           version: '~> v2'
           args: release --clean
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+          # Built-in token: enough for creating the release in this repo.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # PAT with write access to hedhyw/homebrew-main: only needed for
+          # pushing the Homebrew formula to the tap repository.
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.GH_PAT }}
 
   docker:
     runs-on: ubuntu-latest
@@ -33,7 +40,7 @@ jobs:
 
       - name: Set output
         id: vars
-        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+        run: echo "tag=${GITHUB_REF#refs/*/}" >> "$GITHUB_OUTPUT"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,5 @@
+version: 2
+
 builds:
   - binary: otelinji
     main: ./cmd/otelinji
@@ -28,7 +30,8 @@ archives:
       - LICENSE
     format_overrides:
       - goos: windows
-        format: zip
+        formats:
+          - zip
 
 release:
   draft: true
@@ -58,6 +61,9 @@ brews:
     repository:
       owner: hedhyw
       name: homebrew-main
+      # Cross-repo push requires a PAT; the built-in GITHUB_TOKEN cannot
+      # write to other repositories.
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     test: system "#{bin}/otelinji", "-help"
     install: |-
       bin.install "otelinji"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,4 @@
-ARG GOLANG_DOCKER_TAG=1.23.4-alpine3.20
-ARG ALPINE_DOCKER_TAG=3.20
-
-FROM golang:$GOLANG_DOCKER_TAG as builder
+FROM golang:1.25.5-alpine3.22 AS builder
 
 RUN apk update && apk upgrade && apk add --no-cache make
 
@@ -10,7 +7,7 @@ COPY . .
 
 RUN go build -o /build/otelinji cmd/otelinji/main.go
 
-FROM alpine:$ALPINE_DOCKER_TAG
+FROM alpine:3.22
 
 WORKDIR /app
 COPY --from=builder /build/otelinji /app/otelinji


### PR DESCRIPTION
- Use built-in `GITHUB_TOKEN` for the release, PAT only for the brew tap.
- Bump the Go builder image to 1.25.5 (go.mod requires >= 1.25.0), fixing the failed v1.1.1 docker build.
- Inline `FROM` tags and add a docker ecosystem to dependabot so images get bumped automatically.